### PR TITLE
Suppress RAISE NOTICE

### DIFF
--- a/mvtbl--0.0.2.sql
+++ b/mvtbl--0.0.2.sql
@@ -1,3 +1,6 @@
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION mvtbl" to load this file. \quit
+
 CREATE FUNCTION mvtbl(tbl text, tblspace text) 
 RETURNS bigint AS
 $$

--- a/mvtbl.control
+++ b/mvtbl.control
@@ -1,5 +1,5 @@
 # mvtbl extension
 comment = 'Helper to move tables around tablespaces'
-default_version = '0.0.1'
+default_version = '0.0.2'
 relocatable = true
 requires = ''

--- a/test/expected/mvtbl_test.out
+++ b/test/expected/mvtbl_test.out
@@ -4,20 +4,12 @@ CREATE INDEX ON test(a);
 CREATE INDEX ON test(a,b);
 CREATE INDEX ON test(c);
 SELECT pg_size_pretty(mvtbl('test','mvtbl_test_tblspace'));
-NOTICE:  done moving test
-NOTICE:  done moving test_a_b_idx
-NOTICE:  done moving test_a_idx
-NOTICE:  done moving test_c_idx
  pg_size_pretty 
 ----------------
  123 MB
 (1 row)
 
 SELECT pg_size_pretty(mvtbl('test','pg_default'));
-NOTICE:  done moving test
-NOTICE:  done moving test_a_b_idx
-NOTICE:  done moving test_a_idx
-NOTICE:  done moving test_c_idx
  pg_size_pretty 
 ----------------
  123 MB


### PR DESCRIPTION
`mvtbl` is pretty noisy. `RAISE NOTICE` logs message to stderr, therefore it is sent to dba@adjust.com. It clutters up cron alerts.

We can remove `RAISE NOTICE` safely since we already have logging in the script itself:
https://github.com/adjust/db_jobs/blob/3fab4a6e9ab789c34ef958fa86fc292f9c9ca710/backends/scripts/move_to_pg_default.sh#L66