### PR TITLE
add option to retry on lock_not_available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ TESTS        = $(wildcard test/sql/*.sql)
 REGRESS      = $(patsubst test/sql/%.sql,%,$(TESTS))
 REGRESS_OPTS = --inputdir=test \
 			   --load-extension=$(EXTENSION) \
-			   --temp-instance=$$PWD/tmp 
+			   --temp-instance=$$PWD/tmp
 REGRESS_PREP = mktblspace
 SQLSRC = $(wildcard sql/*.sql)
 include $(PGXS)
@@ -21,4 +21,4 @@ $(EXTENSION)--$(EXTVERSION).sql: $(SQLSRC)
 	@cat $^ >> $@
 
 mktblspace:
-	mkdir -p /tmp/tsttblsp	
+	mkdir -p /tmp/tsttblsp

--- a/mvtbl--0.0.2--0.0.3.sql
+++ b/mvtbl--0.0.2--0.0.3.sql
@@ -12,7 +12,10 @@ $$
                 res = mvtbl(tbl, tblspace);
                 EXIT;
             EXCEPTION WHEN lock_not_available THEN
-                pg_sleep(sleep_sec);
+                IF i = retries THEN
+                    RAISE;
+                END IF;
+                PERFORM pg_sleep(sleep_sec);
             END;
         END LOOP;
         RETURN res;

--- a/mvtbl--0.0.2--0.0.3.sql
+++ b/mvtbl--0.0.2--0.0.3.sql
@@ -1,0 +1,20 @@
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "ALTER EXTENSION mvtbl UPDATE TO '0.0.3'" to load this file. \quit
+
+CREATE FUNCTION mvtbl(tbl text, tblspace text, retries int, sleep_sec int DEFAULT 10)
+RETURNS bigint AS
+$$
+    DECLARE
+        res bigint;
+    BEGIN
+        FOR i in 1..retries LOOP
+            BEGIN
+                res = mvtbl(tbl, tblspace);
+                EXIT;
+            EXCEPTION WHEN lock_not_available THEN
+                pg_sleep(sleep_sec);
+            END;
+        END LOOP;
+        RETURN res;
+    END;
+$$ LANGUAGE plpgsql STRICT;

--- a/mvtbl--0.0.3--0.0.2.sql
+++ b/mvtbl--0.0.3--0.0.2.sql
@@ -1,0 +1,4 @@
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "ALTER EXTENSION mvtbl UPDATE TO '0.0.2'" to load this file. \quit
+
+DROP FUNCTION mvtbl(tbl text, tblspace text, retries int, sleep_sec int)

--- a/mvtbl--0.0.3.sql
+++ b/mvtbl--0.0.3.sql
@@ -1,3 +1,6 @@
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION mvtbl" to load this file. \quit
+
 CREATE FUNCTION mvtbl(tbl text, tblspace text)
 RETURNS bigint AS
 $$

--- a/mvtbl--0.0.3.sql
+++ b/mvtbl--0.0.3.sql
@@ -35,7 +35,10 @@ $$
 				res = mvtbl(tbl, tblspace);
 				EXIT;
 			EXCEPTION WHEN lock_not_available THEN
-				pg_sleep(sleep_sec);
+				IF i = retries THEN
+					RAISE;
+				END IF;
+				PERFORM pg_sleep(sleep_sec);
 			END;
 		END LOOP;
 		RETURN res;

--- a/mvtbl.control
+++ b/mvtbl.control
@@ -1,5 +1,5 @@
 # mvtbl extension
 comment = 'Helper to move tables around tablespaces'
-default_version = '0.0.2'
+default_version = '0.0.3'
 relocatable = true
 requires = ''

--- a/sql/mvtbl.sql
+++ b/sql/mvtbl.sql
@@ -32,6 +32,9 @@ $$
 				res = mvtbl(tbl, tblspace);
 				EXIT;
 			EXCEPTION WHEN lock_not_available THEN
+				IF i = retries THEN
+					RAISE;
+				END IF;
 				pg_sleep(sleep_sec);
 			END;
 		END LOOP;

--- a/test/expected/mvtbl_test.out
+++ b/test/expected/mvtbl_test.out
@@ -15,4 +15,18 @@ SELECT pg_size_pretty(mvtbl('test','pg_default'));
  123 MB
 (1 row)
 
+SELECT pg_size_pretty(mvtbl('test','mvtbl_test_tblspace', 3, 3));
+ pg_size_pretty 
+----------------
+ 123 MB
+(1 row)
+
+SELECT pg_size_pretty(mvtbl('test','pg_default', 3));
+ pg_size_pretty 
+----------------
+ 123 MB
+(1 row)
+
+ALTER EXTENSION mvtbl UPDATE TO '0.0.2';
+ALTER EXTENSION mvtbl UPDATE TO '0.0.3';
 DROP TABLESPACE mvtbl_test_tblspace;

--- a/test/sql/mvtbl_test.sql
+++ b/test/sql/mvtbl_test.sql
@@ -8,4 +8,10 @@ CREATE INDEX ON test(c);
 SELECT pg_size_pretty(mvtbl('test','mvtbl_test_tblspace'));
 SELECT pg_size_pretty(mvtbl('test','pg_default'));
 
+SELECT pg_size_pretty(mvtbl('test','mvtbl_test_tblspace', 3, 3));
+SELECT pg_size_pretty(mvtbl('test','pg_default', 3));
+
+ALTER EXTENSION mvtbl UPDATE TO '0.0.2';
+ALTER EXTENSION mvtbl UPDATE TO '0.0.3';
+
 DROP TABLESPACE mvtbl_test_tblspace;


### PR DESCRIPTION
We typically move table with a lock_timeout to avoid to long exclusive locks.
This adds additional parameters retries and sleep_sec to define the number of unsuccessful retries and the nap time between them.