### PR TITLE
Align CI workflow and add Postgres 15 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,8 @@ jobs:
     steps:
       - run: pg-start ${{ matrix.pg }}
       - uses: actions/checkout@v2
-      - run: pg-build-test
+      - run: make install
+      - run: chmod a+w $(pwd)
+      - run: su postgres -c 'make installcheck'
+      - run: cat regression.diffs
+        if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,24 +2,20 @@ name: CI
 
 on:
   push:
-    branches: ['*']
+    branches:
+      - master
+      - main
   pull_request:
-    branches: ['*']
 
 jobs:
   test:
     strategy:
-      fail-fast: false
       matrix:
-        pg: [14, 13, 12, 11, 10, 9.6, 9.5]
-    name: PostgreSQL ${{ matrix.pg }}
+        pg: [15, 14, 13, 12, 11, 10]
+    name: 🐘 PostgreSQL ${{ matrix.pg }}
     runs-on: ubuntu-latest
-    container: zilder/pg-ext-check
+    container: pgxn/pgxn-tools
     steps:
-      - run: pg-setup ${{ matrix.pg }}
+      - run: pg-start ${{ matrix.pg }}
       - uses: actions/checkout@v2
-      - run: make install
-      - run: chmod a+w $(pwd)
-      - run: su postgres -c 'make installcheck'
-      - run: cat regression.diffs
-        if: ${{ failure() }}
+      - run: pg-build-test


### PR DESCRIPTION
We want an improved aligned workflow setup for all
our postgres extensions.
This workflow will run tests after pushing commits into
the main branch and into any open pull request's branch.
It runs tests on PostgreSQL Versions 10 to 15.

One important thing here is that the workflow uses pgxn/pgxn-tools
Docker image. It installs specified version of PostgreSQL and run tests
by pg-build-test, which runs make installcheck under the hood